### PR TITLE
fix: accept empty JSON bodies on task action POSTs

### DIFF
--- a/crates/api/src/extract.rs
+++ b/crates/api/src/extract.rs
@@ -1,0 +1,81 @@
+use axum::body::Bytes;
+use axum::extract::{FromRequest, Request};
+use serde::de::DeserializeOwned;
+
+use crate::errors::ApiError;
+
+/// JSON body that treats a missing or empty payload as `T::default()`.
+///
+/// Axum's `Option<Json<T>>` still fails when the client sends
+/// `Content-Type: application/json` with an empty body (EOF). The webapp
+/// does that on several body-less POSTs, including task Cancel.
+pub struct OptionalJson<T>(pub T);
+
+pub fn parse_optional_json<T: Default + DeserializeOwned>(bytes: &[u8]) -> Result<T, ApiError> {
+    let trimmed = bytes
+        .iter()
+        .copied()
+        .skip_while(u8::is_ascii_whitespace)
+        .collect::<Vec<_>>();
+    if trimmed.is_empty() || trimmed == b"null" {
+        return Ok(T::default());
+    }
+
+    serde_json::from_slice(&trimmed).map_err(|error| {
+        ApiError::bad_request(format!("Failed to parse the request body as JSON: {error}"))
+    })
+}
+
+impl<S, T> FromRequest<S> for OptionalJson<T>
+where
+    T: Default + DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let bytes = Bytes::from_request(req, state)
+            .await
+            .map_err(|error| ApiError::bad_request(error.to_string()))?;
+        parse_optional_json(&bytes).map(Self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use api_types::TaskActionRequest;
+
+    #[test]
+    fn empty_body_is_default() {
+        let parsed = parse_optional_json::<TaskActionRequest>(b"").expect("empty body");
+        assert_eq!(parsed.reason, None);
+        assert_eq!(parsed.version, None);
+    }
+
+    #[test]
+    fn whitespace_body_is_default() {
+        let parsed = parse_optional_json::<TaskActionRequest>(b"  \n").expect("whitespace");
+        assert_eq!(parsed.reason, None);
+    }
+
+    #[test]
+    fn null_body_is_default() {
+        let parsed = parse_optional_json::<TaskActionRequest>(b"null").expect("null");
+        assert_eq!(parsed.version, None);
+    }
+
+    #[test]
+    fn object_body_is_parsed() {
+        let parsed = parse_optional_json::<TaskActionRequest>(br#"{"reason":"stop","version":3}"#)
+            .expect("object");
+        assert_eq!(parsed.reason.as_deref(), Some("stop"));
+        assert_eq!(parsed.version, Some(3));
+    }
+
+    #[test]
+    fn invalid_json_is_rejected() {
+        let error = parse_optional_json::<TaskActionRequest>(b"{").expect_err("invalid");
+        assert!(format!("{error:?}").contains("Failed to parse the request body as JSON"));
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -16,6 +16,7 @@ use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::{DefaultOnResponse, TraceLayer};
 use tracing::Level;
 
+mod extract;
 pub mod errors;
 pub mod middleware;
 mod path_input;

--- a/crates/api/src/routes/tasks/actions.rs
+++ b/crates/api/src/routes/tasks/actions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::extract::OptionalJson;
 
 pub async fn list_task_actions(
     State(state): State<AppState>,
@@ -11,66 +12,65 @@ pub async fn list_task_actions(
 pub async fn start_task(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    body: Option<Json<Option<TaskActionRequest>>>,
+    body: OptionalJson<TaskActionRequest>,
 ) -> ApiResult<Json<TaskResponse>> {
-    execute(&state, id, TaskAction::Start, body).await
+    execute(&state, id, TaskAction::Start, body.0).await
 }
 
 pub async fn pause_task(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    body: Option<Json<Option<TaskActionRequest>>>,
+    body: OptionalJson<TaskActionRequest>,
 ) -> ApiResult<Json<TaskResponse>> {
-    execute(&state, id, TaskAction::Pause, body).await
+    execute(&state, id, TaskAction::Pause, body.0).await
 }
 
 pub async fn resume_task(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    body: Option<Json<Option<TaskActionRequest>>>,
+    body: OptionalJson<TaskActionRequest>,
 ) -> ApiResult<Json<TaskResponse>> {
-    execute(&state, id, TaskAction::Resume, body).await
+    execute(&state, id, TaskAction::Resume, body.0).await
 }
 
 pub async fn submit_task(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    body: Option<Json<Option<TaskActionRequest>>>,
+    body: OptionalJson<TaskActionRequest>,
 ) -> ApiResult<Json<TaskResponse>> {
-    execute(&state, id, TaskAction::Submit, body).await
+    execute(&state, id, TaskAction::Submit, body.0).await
 }
 
 pub async fn request_changes_task(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    body: Option<Json<Option<TaskActionRequest>>>,
+    body: OptionalJson<TaskActionRequest>,
 ) -> ApiResult<Json<TaskResponse>> {
-    execute(&state, id, TaskAction::RequestChanges, body).await
+    execute(&state, id, TaskAction::RequestChanges, body.0).await
 }
 
 pub async fn approve_task(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    body: Option<Json<Option<TaskActionRequest>>>,
+    body: OptionalJson<TaskActionRequest>,
 ) -> ApiResult<Json<TaskResponse>> {
-    execute(&state, id, TaskAction::Approve, body).await
+    execute(&state, id, TaskAction::Approve, body.0).await
 }
 
 pub async fn cancel_task(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    body: Option<Json<Option<TaskActionRequest>>>,
+    body: OptionalJson<TaskActionRequest>,
 ) -> ApiResult<Json<TaskResponse>> {
-    execute(&state, id, TaskAction::Cancel, body).await
+    execute(&state, id, TaskAction::Cancel, body.0).await
 }
 
 async fn execute(
     state: &AppState,
     id: String,
     action: TaskAction,
-    body: Option<Json<Option<TaskActionRequest>>>,
+    request: TaskActionRequest,
 ) -> ApiResult<Json<TaskResponse>> {
-    let request = body.and_then(|body| body.0).unwrap_or_default();
     let result = state
         .task_service
         .perform_task_action(id, action, request.reason, request.version)

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -20,6 +20,39 @@ describe('apiFetch', () => {
     ).resolves.toBeUndefined()
   })
 
+  it('does not send application/json when the request has no body', async () => {
+    const fetchMock = vi.spyOn(window, 'fetch').mockResolvedValue(
+      new Response(null, {
+        status: 204,
+        statusText: 'No Content',
+      }),
+    )
+
+    await apiFetch<void>('/tasks/task-id/cancel', { method: 'POST' })
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit
+    const headers = new Headers(init.headers)
+    expect(headers.get('content-type')).toBeNull()
+  })
+
+  it('sets application/json when sending a JSON body', async () => {
+    const fetchMock = vi.spyOn(window, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    await apiFetch<{ ok: boolean }>('/tasks/task-id/cancel', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    })
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit
+    const headers = new Headers(init.headers)
+    expect(headers.get('content-type')).toBe('application/json')
+  })
+
   it('parses successful JSON responses', async () => {
     vi.spyOn(window, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({ ok: true }), {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -58,7 +58,11 @@ async function apiResponse(path: string, init?: ApiFetchInit): Promise<Response>
   const makeHeaders = (overrideToken?: string) => {
     const h = new Headers(headers)
     const isFormDataBody = typeof FormData !== 'undefined' && fetchInit.body instanceof FormData
-    if (!h.has('content-type') && !isFormDataBody) {
+    const hasJsonBody =
+      fetchInit.body !== undefined && fetchInit.body !== null && fetchInit.body !== '' && !isFormDataBody
+    // Only advertise JSON when a body is present. Axum's Json extractor
+    // treats `Content-Type: application/json` + empty body as a parse error.
+    if (!h.has('content-type') && hasJsonBody) {
       h.set('content-type', 'application/json')
     }
     const token = overrideToken ?? useAuthStore.getState().accessToken


### PR DESCRIPTION
## Summary
- The web client always set `Content-Type: application/json`, including on body-less POSTs such as Task Cancel.
- Axum then tried to parse an empty JSON body and returned `EOF while parsing a value`.
- Stop sending that header when there is no body, and treat empty/null task-action payloads as the default request on the server.

## Test plan
- [ ] In the webapp, Cancel a task that is planning or running (no request body). The action should succeed instead of `Failed to parse the request body as JSON: EOF`.
- [ ] Pause / resume / start / approve with an optional reason body still work.
- [ ] `forge-ctl task cancel <id>` still works.
- [ ] `cargo test -p api extract::`
- [ ] `pnpm test -- src/api/client.test.ts` from `web/`


Made with [Cursor](https://cursor.com)