### PR TITLE
feat: discover Cursor models for the agent picker

### DIFF
--- a/crates/cli-adapters/src/cursor.rs
+++ b/crates/cli-adapters/src/cursor.rs
@@ -20,6 +20,7 @@ use tokio_util::sync::CancellationToken;
 const DEFAULT_MAX_OUTPUT_BYTES: u64 = 10 * 1024 * 1024;
 const MAX_SUMMARY_CHARS: usize = 500;
 const STATUS_TIMEOUT_SECONDS: u64 = 2;
+const LIST_MODELS_TIMEOUT_SECONDS: u64 = 5;
 
 pub struct CursorAdapter {
     processes: Arc<Mutex<HashMap<String, RunningProcess>>>,
@@ -126,7 +127,7 @@ impl CodingExecutorAdapter for CursorAdapter {
         _ctx: DiscoverContext,
     ) -> Result<DiscoveredOptions, ExecutorError> {
         Ok(DiscoveredOptions {
-            models: vec![],
+            models: discover_cursor_models(),
             permission_policies: vec!["auto".into(), "supervised".into(), "plan".into()],
             cli_specific: serde_json::json!({
                 "output_formats": ["text", "json", "stream-json"],
@@ -515,6 +516,60 @@ fn truncate_summary(content: &str) -> String {
     }
 }
 
+fn default_cursor_models() -> Vec<String> {
+    vec![
+        "auto".into(),
+        "composer-2.5".into(),
+        "composer-2.5-fast".into(),
+        "cursor-grok-4.6-medium-fast".into(),
+        "cursor-grok-4.6-high-fast".into(),
+        "cursor-grok-4.6-xhigh-fast".into(),
+        "claude-sonnet-5-thinking-high".into(),
+        "claude-opus-5-thinking-high".into(),
+        "gpt-5.6-sol-high".into(),
+        "gpt-5.3-codex".into(),
+    ]
+}
+
+fn parse_cursor_list_models(output: &str) -> Vec<String> {
+    let mut models = Vec::new();
+    for line in output.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.eq_ignore_ascii_case("available models") {
+            continue;
+        }
+        let Some((id, _)) = line.split_once(" - ") else {
+            continue;
+        };
+        let id = id.trim();
+        if id.is_empty() || id.contains(' ') {
+            continue;
+        }
+        if !models.iter().any(|existing| existing == id) {
+            models.push(id.to_owned());
+        }
+    }
+    models
+}
+
+fn discover_cursor_models() -> Vec<String> {
+    if executable_in_path("cursor-agent") {
+        let mut command = std::process::Command::new("cursor-agent");
+        command.arg("--list-models");
+        if let Some(output) =
+            command_output_timeout(command, Duration::from_secs(LIST_MODELS_TIMEOUT_SECONDS))
+        {
+            if output.status.success() {
+                let parsed = parse_cursor_list_models(&String::from_utf8_lossy(&output.stdout));
+                if !parsed.is_empty() {
+                    return parsed;
+                }
+            }
+        }
+    }
+    default_cursor_models()
+}
+
 fn detect_cursor_availability() -> AvailabilityInfo {
     if std::env::var("CURSOR_API_KEY")
         .ok()
@@ -665,6 +720,23 @@ mod tests {
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect();
         assert!(args.contains(&"--force".to_owned()));
+    }
+
+    #[test]
+    fn parses_cursor_list_models_text() {
+        let models = parse_cursor_list_models(
+            "Available models\n\nauto - Auto (default)\ncursor-grok-4.6-medium-fast - Cursor Grok 4.6 Medium Fast\n",
+        );
+        assert_eq!(
+            models,
+            vec!["auto", "cursor-grok-4.6-medium-fast"]
+        );
+    }
+
+    #[test]
+    fn default_cursor_models_are_non_empty() {
+        assert!(default_cursor_models().contains(&"auto".to_owned()));
+        assert!(default_cursor_models().contains(&"cursor-grok-4.6-medium-fast".to_owned()));
     }
 
     #[test]

--- a/web/src/components/execution-config/ExecutionConfigBar.tsx
+++ b/web/src/components/execution-config/ExecutionConfigBar.tsx
@@ -108,6 +108,8 @@ export function ExecutionConfigBar({
 
   useEffect(() => {
     if (!discoveredOptions || !config.modelId) return
+    // An empty catalog (historically Cursor) must not wipe a selected or custom id.
+    if (discoveredOptions.models.length === 0) return
     if (!discoveredOptions.models.some((m) => m.id === config.modelId)) {
       config.setModelId(null)
     }

--- a/web/src/hooks/useDiscoveredOptions.test.ts
+++ b/web/src/hooks/useDiscoveredOptions.test.ts
@@ -50,6 +50,18 @@ describe('normalizeDiscoveredOptions', () => {
     })
   })
 
+  it('labels cursor, grok, and gemini model providers', () => {
+    const options = normalizeDiscoveredOptions({
+      models: ['cursor-grok-4.6-medium-fast', 'composer-2.5', 'gemini-3.7-flash-high'],
+    })
+
+    expect(options.models.map((model) => [model.id, model.provider])).toEqual([
+      ['cursor-grok-4.6-medium-fast', 'xAI'],
+      ['composer-2.5', 'Cursor'],
+      ['gemini-3.7-flash-high', 'Google'],
+    ])
+  })
+
   it('keeps the legacy shared effort fallback when adapters omit per-model metadata', () => {
     const options = normalizeDiscoveredOptions({ models: ['custom-model'] })
 

--- a/web/src/hooks/useDiscoveredOptions.ts
+++ b/web/src/hooks/useDiscoveredOptions.ts
@@ -39,6 +39,9 @@ function providerForModel(modelId: string): string | null {
   const lower = modelId.toLowerCase()
   if (lower.includes('claude')) return 'Anthropic'
   if (lower.includes('gpt') || lower.includes('codex') || lower.includes('o3')) return 'OpenAI'
+  if (lower.includes('grok')) return 'xAI'
+  if (lower.includes('gemini')) return 'Google'
+  if (lower.includes('composer') || lower.startsWith('cursor-')) return 'Cursor'
   return null
 }
 


### PR DESCRIPTION
## Summary
- The Cursor adapter hardcoded `models: []`, so Agent Settings and the execution model picker had no catalog.
- Discover models via `cursor-agent --list-models` when the CLI is on PATH, and fall back to a short known list if discovery fails.
- Do not clear a selected model when discovery returns an empty catalog.

## Test plan
- [ ] `GET /api/v1/agents/{cursor-agent-id}/discovered-options` returns a non-empty `models` list.
- [ ] Agent Settings → Change model shows Cursor/Grok/Composer suggestions.
- [ ] Task execution config model dropdown is populated for a Cursor identity.
- [ ] Selecting a model persists on the agent / execution override.
- [ ] `cargo test -p cli-adapters parses_cursor_list_models_text`
- [ ] `pnpm test -- src/hooks/useDiscoveredOptions.test.ts` from `web/`


Made with [Cursor](https://cursor.com)