### PR TITLE
fix: keep gate readiness on task version snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Forge follows Semantic Versioning. During the `0.x` public beta period, APIs and
 
 ## [Unreleased]
 
+### Fixed
+
+- **A Review gate no longer reports `awaiting_human` before its entry has
+  settled.** Entering a state with blocking `before_enter` hooks persists the
+  transition behind a running entry barrier, and the engine clears that barrier
+  (bumping the Task version) once the hooks finish. `awaiting_human` could
+  already read true in between, so a client that read the Task and then
+  approved or rejected with that version hit a spurious `version_conflict`.
+  `awaiting_human` is now derived from the same Task snapshot as the returned
+  `version`, staying false while that snapshot's barrier is running. The
+  `POST /api/v1/tasks/{id}/gates/{state}/approve` and `/reject` endpoints also
+  refuse with 409 `validation_error` until it clears.
+
 ## [0.9.0] - 2026-09-02
 
 ### Breaking

--- a/crates/api/src/routes/tasks/crud.rs
+++ b/crates/api/src/routes/tasks/crud.rs
@@ -157,10 +157,10 @@ pub async fn get_task(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> ApiResult<Json<TaskResponse>> {
-    let awaiting_human = state.task_service.is_awaiting_human(id.clone()).await?;
     let task = TaskRepo::get_by_id(&*state.db, &id, false)
         .await?
         .ok_or_else(|| ApiError::not_found("task", id))?;
+    let awaiting_human = state.task_service.is_task_awaiting_human(&task).await?;
     let response = task_response_with_awaiting_human(&state.db, task, awaiting_human).await?;
     Ok(Json(response))
 }

--- a/crates/api/src/routes/tasks/gates.rs
+++ b/crates/api/src/routes/tasks/gates.rs
@@ -71,6 +71,11 @@ async fn transition_gate(
             task.status
         )));
     }
+    if task.entry_barrier_is_running() {
+        return Err(ApiError::invalid_operation_conflict(format!(
+            "gate '{state_name}' is still running its entry checks; wait for them to finish before approving or rejecting"
+        )));
+    }
     ensure_gate_decision_ready(state, &task_id, gate_state).await?;
 
     if decision == GateDecision::Approve && state_name == default_states::REVIEW {
@@ -83,11 +88,9 @@ async fn transition_gate(
             .is_some_and(|review| review.status == ReviewStatus::AwaitingHuman)
         {
             let (task, _) = state.task_service.approve_review(task_id).await?;
-            let mut response = task_response(&state.db, task).await?;
-            response.awaiting_human = state
-                .task_service
-                .is_awaiting_human(response.id.clone())
-                .await?;
+            let awaiting_human = state.task_service.is_task_awaiting_human(&task).await?;
+            let response =
+                task_response_with_awaiting_human(&state.db, task, awaiting_human).await?;
             return Ok(response);
         }
     }
@@ -107,11 +110,12 @@ async fn transition_gate(
         )
         .await?;
 
-    let mut response = task_response(&state.db, result.task).await?;
-    response.awaiting_human = state
+    let awaiting_human = state
         .task_service
-        .is_awaiting_human(response.id.clone())
+        .is_task_awaiting_human(&result.task)
         .await?;
+    let response =
+        task_response_with_awaiting_human(&state.db, result.task, awaiting_human).await?;
     Ok(response)
 }
 

--- a/crates/api/src/routes/tasks/transitions.rs
+++ b/crates/api/src/routes/tasks/transitions.rs
@@ -15,11 +15,12 @@ pub async fn transition_task(
         .task_service
         .transition(id, request.status, options)
         .await?;
-    let mut response = task_response(&state.db, result.task).await?;
-    response.awaiting_human = state
+    let awaiting_human = state
         .task_service
-        .is_awaiting_human(response.id.clone())
+        .is_task_awaiting_human(&result.task)
         .await?;
+    let response =
+        task_response_with_awaiting_human(&state.db, result.task, awaiting_human).await?;
     Ok(Json(TransitionTaskResponse {
         task: response,
         review: result.review.map(review_response),

--- a/crates/db/src/task_metadata.rs
+++ b/crates/db/src/task_metadata.rs
@@ -30,6 +30,25 @@ impl Task {
     pub fn metadata(&self) -> Result<TaskMetadata, serde_json::Error> {
         TaskMetadata::parse(self.metadata_json.as_deref())
     }
+
+    /// The `status` field of the task's entry barrier, when one is recorded.
+    ///
+    /// The workflow engine persists a transition into a state that has blocking
+    /// `before_enter` hooks behind an entry barrier: `running` while the hooks
+    /// execute, `blocked` when one of them failed and the task needs attention.
+    pub fn entry_barrier_status(&self) -> Option<String> {
+        let raw = self.entry_barrier_json.as_deref()?;
+        let barrier: Value = serde_json::from_str(raw).ok()?;
+        barrier.get("status")?.as_str().map(str::to_owned)
+    }
+
+    /// True while the task's current state is still running its blocking
+    /// `before_enter` hooks. The status change is already visible, but the
+    /// transition has not settled: the engine clears the barrier (bumping the
+    /// task version) once the hooks finish.
+    pub fn entry_barrier_is_running(&self) -> bool {
+        self.entry_barrier_status().as_deref() == Some("running")
+    }
 }
 
 #[cfg(test)]
@@ -52,5 +71,58 @@ mod tests {
     #[test]
     fn task_metadata_to_json_omits_empty_metadata() {
         assert_eq!(TaskMetadata::default().to_json(), None);
+    }
+
+    fn task_with_entry_barrier(entry_barrier_json: Option<&str>) -> Task {
+        Task {
+            id: "task".to_owned(),
+            project_id: "project".to_owned(),
+            repo_id: None,
+            parent_task_id: None,
+            assignee_type: None,
+            assignee_id: None,
+            title: "task".to_owned(),
+            description: None,
+            task_type: "task".to_owned(),
+            status: "review".to_owned(),
+            is_automation: false,
+            priority: 0,
+            board_position: 0.0,
+            subtask_order: None,
+            task_state_config: None,
+            merge_config: None,
+            metadata_json: None,
+            plan: None,
+            error_annotation: None,
+            blocked_json: None,
+            failed_json: None,
+            entry_barrier_json: entry_barrier_json.map(str::to_owned),
+            review_passed_at: None,
+            archived_at: None,
+            deleted_at: None,
+            version: 1,
+            created_at: "2026-01-01T00:00:00Z".to_owned(),
+            updated_at: "2026-01-01T00:00:00Z".to_owned(),
+        }
+    }
+
+    #[test]
+    fn entry_barrier_is_running_only_for_a_running_barrier() {
+        assert!(task_with_entry_barrier(Some(
+            r#"{"state":"review","status":"running","started_at":"2026-01-01T00:00:00Z"}"#
+        ))
+        .entry_barrier_is_running());
+        assert!(!task_with_entry_barrier(Some(
+            r#"{"state":"review","status":"blocked","blocking_reason":"ci"}"#
+        ))
+        .entry_barrier_is_running());
+        assert!(!task_with_entry_barrier(None).entry_barrier_is_running());
+        assert!(!task_with_entry_barrier(Some("not json")).entry_barrier_is_running());
+        assert_eq!(
+            task_with_entry_barrier(Some(r#"{"status":"blocked"}"#))
+                .entry_barrier_status()
+                .as_deref(),
+            Some("blocked")
+        );
     }
 }

--- a/crates/services/src/task_service/tests/service_tests/cases/transitions.rs
+++ b/crates/services/src/task_service/tests/service_tests/cases/transitions.rs
@@ -295,3 +295,114 @@ async fn transition_to_review_runs_configured_review_runner() {
         Some(ReviewStatus::Passed)
     );
 }
+
+#[tokio::test]
+async fn is_awaiting_human_stays_false_while_review_entry_barrier_is_running() {
+    let db = Arc::new(sqlite_db().await);
+    let event_bus = Arc::new(EventBus::new(16));
+    let service = TaskService::new(Arc::clone(&db), event_bus);
+    let (project_id, repo_id, _repo_dir) = seed_project_repo(&db).await;
+    let agent_id = seed_agent(&db).await;
+    let task = seed_task_with_status(&db, &project_id, &repo_id, "review".to_owned()).await;
+    let now = now_rfc3339();
+    let execution = ExecutionRepo::create(
+        &*db,
+        db::CreateExecution {
+            id: new_uuid_v4(),
+            task_id: task.id.clone(),
+            agent_id: Some(agent_id),
+            role: default_roles::CODER.to_owned(),
+            status: ExecutionStatus::Completed,
+            stop_reason: None,
+            stopped_by: None,
+            resume_policy: None,
+            stopped_at: None,
+            parent_execution_id: None,
+            agent_session_id: None,
+            agent_message_id: None,
+            last_activity_at: None,
+            summary: None,
+            logs_path: None,
+            before_sha: None,
+            after_sha: None,
+            error: None,
+            executor_config_snapshot_json: None,
+            workspace_id: None,
+            created_at: now.clone(),
+            updated_at: now.clone(),
+        },
+    )
+    .await
+    .expect("completed coder execution creates");
+    ReviewRepo::create(
+        &*db,
+        db::CreateReview {
+            id: new_uuid_v4(),
+            task_id: task.id.clone(),
+            execution_id: execution.id,
+            attempt_number: 1,
+            status: ReviewStatus::AwaitingHuman,
+            step_results_json: json!({ "ci_steps": [] }).to_string(),
+            started_at: now.clone(),
+            created_at: now.clone(),
+            updated_at: now.clone(),
+        },
+    )
+    .await
+    .expect("awaiting_human review creates");
+
+    assert!(
+        service
+            .is_awaiting_human(task.id.clone())
+            .await
+            .expect("awaiting human resolves"),
+        "a settled review gate with an awaiting_human review is ready for a decision"
+    );
+
+    // Mirror the engine: a transition into review is persisted behind a running
+    // entry barrier while the blocking before_enter hooks execute, and the
+    // review record can already read awaiting_human before that barrier clears.
+    let running = TaskRepo::set_entry_barrier(
+        &*db,
+        &task.id,
+        task.version,
+        Some(
+            json!({
+                "state": "review",
+                "status": "running",
+                "started_at": now,
+            })
+            .to_string(),
+        ),
+        &now_rfc3339(),
+    )
+    .await
+    .expect("running entry barrier sets");
+    assert!(
+        !service
+            .is_task_awaiting_human(&running)
+            .await
+            .expect("awaiting human resolves"),
+        "the gate is not ready for a decision while its entry barrier is still running"
+    );
+
+    let cleared =
+        TaskRepo::set_entry_barrier(&*db, &task.id, running.version, None, &now_rfc3339())
+            .await
+            .expect("entry barrier clears");
+    assert_eq!(cleared.version, running.version + 1);
+    assert!(
+        !service
+            .is_task_awaiting_human(&running)
+            .await
+            .expect("stale snapshot readiness resolves"),
+        "a stale running-barrier snapshot must not be paired with readiness from a newer version"
+    );
+    assert!(
+        service
+            .is_task_awaiting_human(&cleared)
+            .await
+            .expect("awaiting human resolves"),
+        "the gate becomes ready once the entry barrier has cleared"
+    );
+}

--- a/crates/services/src/task_service/transition.rs
+++ b/crates/services/src/task_service/transition.rs
@@ -240,8 +240,21 @@ impl TaskService {
         let task = TaskRepo::get_by_id(&*self.db, &task_id, false)
             .await?
             .ok_or_else(|| ServiceError::not_found("task", task_id.clone()))?;
+        self.is_task_awaiting_human(&task).await
+    }
+
+    /// Resolve human-readiness from the same Task snapshot whose version will
+    /// be returned to the caller.
+    pub async fn is_task_awaiting_human(&self, task: &Task) -> Result<bool> {
         if task.blocked_json.is_some() {
             return Ok(true);
+        }
+        if task.entry_barrier_is_running() {
+            // The state's blocking before_enter hooks are still running. The
+            // status change is visible but the transition has not settled: the
+            // engine clears the barrier (bumping the task version) once they
+            // finish, so a gate decision taken now would race that write.
+            return Ok(false);
         }
         let metadata = TaskMetadata::parse(task.metadata_json.as_deref()).map_err(|error| {
             ServiceError::invalid_operation(format!("invalid task metadata: {error}"))
@@ -255,7 +268,7 @@ impl TaskService {
             return Ok(true);
         }
         if task.status == crate::workflow::default_states::REVIEW {
-            let latest_review = ReviewRepo::list_by_task(&*self.db, &task_id)
+            let latest_review = ReviewRepo::list_by_task(&*self.db, &task.id)
                 .await?
                 .into_iter()
                 .max_by_key(|review| review.attempt_number);
@@ -270,7 +283,7 @@ impl TaskService {
             .await?
             .ok_or_else(|| ServiceError::not_found("project", task.project_id.clone()))?;
         let workflow = WorkflowEngine::resolve_workflow_for_task(
-            &task,
+            task,
             &project.workflow_definition,
             &Actor::system(SystemComponent::General),
         );
@@ -286,7 +299,7 @@ impl TaskService {
                 return Ok(false);
             };
             let assignment =
-                TaskRoleAssignmentRepo::get_by_task_and_role(&*self.db, &task_id, role_name)
+                TaskRoleAssignmentRepo::get_by_task_and_role(&*self.db, &task.id, role_name)
                     .await?;
             return Ok(assignment.as_ref().is_some_and(|assignment| {
                 assignment.assignee_type == Some(AssigneeKind::User)
@@ -296,7 +309,7 @@ impl TaskService {
         if state.kind != api_types::StateKind::Gate {
             return Ok(false);
         }
-        let transition_log = TransitionLogRepo::list_by_task(&*self.db, &task_id).await?;
+        let transition_log = TransitionLogRepo::list_by_task(&*self.db, &task.id).await?;
         let entered_at = transition_log
             .iter()
             .rev()
@@ -319,7 +332,7 @@ impl TaskService {
                     return Ok(false);
                 };
                 let assignment =
-                    TaskRoleAssignmentRepo::get_by_task_and_role(&*self.db, &task_id, role_name)
+                    TaskRoleAssignmentRepo::get_by_task_and_role(&*self.db, &task.id, role_name)
                         .await?;
                 let assigned = assignment.as_ref().is_some_and(|assignment| {
                     assignment.assignee_type.is_some() && assignment.assignee_id.is_some()
@@ -335,7 +348,7 @@ impl TaskService {
             return Ok(false);
         };
 
-        let role_assignments = TaskRoleAssignmentRepo::list_by_task(&*self.db, &task_id).await?;
+        let role_assignments = TaskRoleAssignmentRepo::list_by_task(&*self.db, &task.id).await?;
         let Some(assignment) = role_assignments
             .iter()
             .find(|assignment| assignment.role_name == role_name)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1138,6 +1138,14 @@ state, the server auto-escalates to the user-routing-override path. MCP
 `forge_transition_task` is unchanged — it still emits `triggered_by="system"`
 and does not support user override (REST-only for now).
 
+`POST /api/v1/tasks/{id}/gates/{state_name}/approve` and `/reject` accept the
+current Task `version`. A gate with blocking entry checks is not decision-ready
+until its entry barrier settles: Task responses keep `awaiting_human = false`
+for that Task snapshot, and an early decision returns HTTP 409 with
+`code: "validation_error"`. The response's `awaiting_human` value and `version`
+are derived from the same Task snapshot so a barrier-clear write cannot expose
+readiness paired with the version it just invalidated.
+
 ## Task intent actions
 
 Intent endpoints accept an optional `TaskActionRequest` body:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1404,6 +1404,12 @@ defined states.
 6. If an `after_enter` hook returns `HookResult::Cascade`, recursively
    transition with `triggered_by = "system"`; cascade depth is limited to 3.
 
+A state with blocking `before_enter` hooks is persisted with a running entry
+barrier until those hooks settle. Task responses derive `awaiting_human` from
+the same Task snapshot as the returned optimistic `version`; a running barrier
+therefore cannot expose a gate decision using a version that the barrier-clear
+write is about to invalidate.
+
 **Dispatch failure entering an active state:** when a dispatch hook
 (`dispatch_role_agent` / `dispatch_fix_agent` / `dispatch_executor`) fails
 `on_enter` of an `active` state and the task has no running execution, the


### PR DESCRIPTION
## Summary
- derive awaiting_human from the same Task snapshot as the returned optimistic version
- keep Review gates non-actionable while blocking entry hooks are still running
- add regression coverage for stale and settled entry-barrier snapshots
- document the gate-readiness contract

## Root cause
The task route previously loaded awaiting_human and the Task/version separately. A Review entry barrier could clear between those reads, returning readiness from version N+1 alongside stale version N. The next approve or reject request then failed with version_conflict.

## Validation
- cargo fmt --all -- --check
- git diff --check
- focused services regression test
- cargo test -p api --test happy_path: 2 passed
- clippy for db, services, and api with warnings denied